### PR TITLE
Add transformer benchmark

### DIFF
--- a/backend-comparison/Cargo.toml
+++ b/backend-comparison/Cargo.toml
@@ -44,7 +44,9 @@ dirs = "5.0.1"
 indicatif = "0.17.11"
 log = { version = "0.4.25", default-features = false }
 os_info = "3.10.0"
-phf = {version = "0.11.3", features = ["macros"] } # for package info static map
+phf = { version = "0.11.3", features = [
+    "macros",
+] } # for package info static map
 percent-encoding = "2.3.1"
 rand = { version = "0.9.0", default-features = false, features = [
     "std_rng",
@@ -130,6 +132,11 @@ path = "benches/load_record.rs"
 harness = false
 name = "custom-gelu"
 path = "benches/custom_gelu.rs"
+
+[[bench]]
+harness = false
+name = "transformer-encoder"
+path = "benches/transformer_encoder.rs"
 
 [[bench]]
 harness = false

--- a/backend-comparison/benches/transformer_encoder.rs
+++ b/backend-comparison/benches/transformer_encoder.rs
@@ -1,0 +1,238 @@
+use backend_comparison::persistence::save;
+use burn::{
+    backend::Autodiff, nn::{
+        loss::CrossEntropyLossConfig, transformer::{TransformerEncoder, TransformerEncoderConfig, TransformerEncoderInput}, Embedding, EmbeddingConfig, Linear, LinearConfig
+    }, prelude::*, tensor::{activation::softmax, backend::AutodiffBackend}
+};
+use burn_common::benchmark::{run_benchmark, Benchmark};
+
+
+#[derive(Debug, Clone)]
+pub struct TrainingBatch<B: Backend> {
+    pub tokens: Tensor<B, 2, Int>,
+    pub labels: Tensor<B, 1, Int>,
+    pub mask_pad: Tensor<B, 2, Bool>, 
+}
+
+#[derive(Debug, Clone)]
+pub struct InferenceBatch<B: Backend> {
+    pub tokens: Tensor<B, 2, Int>,
+    pub mask_pad: Tensor<B, 2, Bool>,
+}
+
+
+#[derive(Config)]
+pub struct ModelConfig {
+    transformer: TransformerEncoderConfig,
+    n_classes: usize,
+    vocab_size: usize,
+    max_seq_length: usize,
+}
+
+#[derive(Module, Debug)]
+pub struct Model<B: Backend> {
+    transformer: TransformerEncoder<B>,
+    embedding_token: Embedding<B>,
+    embedding_pos: Embedding<B>,
+    output: Linear<B>,
+    n_classes: usize,
+    max_seq_length: usize,
+}
+
+impl ModelConfig {
+    pub fn init<B: Backend>(&self, device: &B::Device) -> Model<B> {
+        let output = LinearConfig::new(self.transformer.d_model, self.n_classes).init(device);
+        let transformer = self.transformer.init(device);
+        let embedding_token =
+            EmbeddingConfig::new(self.vocab_size, self.transformer.d_model).init(device);
+        let embedding_pos =
+            EmbeddingConfig::new(self.max_seq_length, self.transformer.d_model).init(device);
+
+        Model {
+            transformer,
+            embedding_token,
+            embedding_pos,
+            output,
+            n_classes: self.n_classes,
+            max_seq_length: self.max_seq_length,
+        }
+    }
+}
+
+/// Define model behavior
+impl<B: Backend> Model<B> {
+    pub fn forward(&self, item: TrainingBatch<B>) -> (Tensor<B, 1>, Tensor<B, 2>, Tensor<B, 1, Int>){
+        // Get batch and sequence length, and the device
+        let [batch_size, seq_length] = item.tokens.dims();
+        let device = &self.embedding_token.devices()[0];
+
+        // Move tensors to the correct device
+        let tokens = item.tokens.to_device(device);
+        let labels = item.labels.to_device(device);
+        let mask_pad = item.mask_pad.to_device(device);
+
+        // Calculate token and position embeddings, and combine them
+        let index_positions = Tensor::arange(0..seq_length as i64, device)
+            .reshape([1, seq_length])
+            .repeat_dim(0, batch_size);
+        let embedding_positions = self.embedding_pos.forward(index_positions);
+        let embedding_tokens = self.embedding_token.forward(tokens);
+        let embedding = (embedding_positions + embedding_tokens) / 2;
+
+        // Perform transformer encoding, calculate output and loss
+        let encoded = self
+            .transformer
+            .forward(TransformerEncoderInput::new(embedding).mask_pad(mask_pad));
+        let output = self.output.forward(encoded);
+
+        let output_classification = output
+            .slice([0..batch_size, 0..1])
+            .reshape([batch_size, self.n_classes]);
+
+        let loss = CrossEntropyLossConfig::new()
+            .init(&output_classification.device())
+            .forward(output_classification.clone(), labels.clone());
+
+        (
+            loss,
+            output_classification,
+            labels,
+        )
+    }
+
+    /// Defines forward pass for inference
+    pub fn infer(&self, item: InferenceBatch<B>) -> Tensor<B, 2> {
+        // Get batch and sequence length, and the device
+        let [batch_size, seq_length] = item.tokens.dims();
+        let device = &self.embedding_token.devices()[0];
+
+        // Move tensors to the correct device
+        let tokens = item.tokens.to_device(device);
+        let mask_pad = item.mask_pad.to_device(device);
+
+        // Calculate token and position embeddings, and combine them
+        let index_positions = Tensor::arange(0..seq_length as i64, device)
+            .reshape([1, seq_length])
+            .repeat_dim(0, batch_size);
+        let embedding_positions = self.embedding_pos.forward(index_positions);
+        let embedding_tokens = self.embedding_token.forward(tokens);
+        let embedding = (embedding_positions + embedding_tokens) / 2;
+
+        // Perform transformer encoding, calculate output and apply softmax for prediction
+        let encoded = self
+            .transformer
+            .forward(TransformerEncoderInput::new(embedding).mask_pad(mask_pad));
+        let output = self.output.forward(encoded);
+        let output = output
+            .slice([0..batch_size, 0..1])
+            .reshape([batch_size, self.n_classes]);
+
+        softmax(output, 1)
+    }
+}
+
+pub struct TransformerEncoderBenchmark<B: Backend, const AD: bool> {
+    shape: Shape,
+    device: B::Device,
+    config: ModelConfig,
+}
+
+impl<B: AutodiffBackend> Benchmark for TransformerEncoderBenchmark<B, true> {
+    type Args = (Model<B>, TrainingBatch<B>);
+
+    fn name(&self) -> String {
+        format!("transformer-encoder-training-{}", core::any::type_name::<B::FloatElem>())
+    }
+
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec![self.shape.dims.clone()]
+    }
+
+    fn execute(&self, (model, input): Self::Args) {
+        let (loss, ..) = model.forward(input);
+        let _grad = loss.backward();
+    }
+
+    fn prepare(&self) -> Self::Args {
+        (
+            self.config.init(&self.device),
+        TrainingBatch {
+            tokens: Tensor::arange(0..self.shape.num_elements() as i64, &self.device).reshape(self.shape.clone()),
+            labels: Tensor::arange(0..self.shape.dims[0] as i64, &self.device),
+            mask_pad: Tensor::<B, 2>::zeros(self.shape.clone(), &self.device).equal_elem(0.0),
+        })
+    }
+
+    fn sync(&self) {
+        B::sync(&self.device)
+    }
+}
+
+
+impl<B: Backend> Benchmark for TransformerEncoderBenchmark<B, false> {
+    type Args = (Model<B>, InferenceBatch<B>);
+
+    fn name(&self) -> String {
+        format!("transformer-encoder-inference-{}", core::any::type_name::<B::FloatElem>())
+    }
+
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec![self.shape.dims.clone()]
+    }
+
+    fn execute(&self, (model, input): Self::Args) {
+        let _out = model.infer(input);
+    }
+
+    fn prepare(&self) -> Self::Args {
+        (
+            self.config.init(&self.device),
+            InferenceBatch {
+            tokens: Tensor::arange(0..self.shape.num_elements() as i64, &self.device).reshape(self.shape.clone()),
+            mask_pad: Tensor::<B, 2>::zeros(self.shape.clone(), &self.device).equal_elem(0.0),
+        })
+    }
+
+    fn sync(&self) {
+        B::sync(&self.device)
+    }
+}
+
+#[allow(dead_code)]
+fn bench<B: Backend>(
+    device: &B::Device,
+    feature_name: &str,
+    url: Option<&str>,
+    token: Option<&str>,
+) {
+    // Something similar to RoBERTa-base.
+    let config = ModelConfig::new(TransformerEncoderConfig::new(768, 3072, 12, 12)
+            .with_norm_first(true), 10, 50_265, 512);
+
+    let batch_size = 2;
+    let sequence_length = 256;
+    let shape = [batch_size, sequence_length];
+    let benchmark_inference = TransformerEncoderBenchmark::<B, false> {
+        shape: shape.into(),
+        device: device.clone(),
+        config: config.clone(),
+    };
+    let benchmark_training = TransformerEncoderBenchmark::<Autodiff<B>, true> {
+        shape: shape.into(),
+        device: device.clone(),
+        config,
+    };
+
+    save::<B>(
+        vec![run_benchmark(benchmark_inference), run_benchmark(benchmark_training)],
+        device,
+        feature_name,
+        url,
+        token,
+    )
+    .unwrap();
+}
+
+fn main() {
+    backend_comparison::bench_on_backend!();
+}

--- a/backend-comparison/src/burnbenchapp/base.rs
+++ b/backend-comparison/src/burnbenchapp/base.rs
@@ -101,6 +101,8 @@ enum BenchmarkValues {
     Binary,
     #[strum(to_string = "custom-gelu")]
     CustomGelu,
+    #[strum(to_string = "transformer-encoder")]
+    TransformerEncoder,
     #[strum(to_string = "data")]
     Data,
     #[strum(to_string = "matmul")]

--- a/backend-comparison/src/lib.rs
+++ b/backend-comparison/src/lib.rs
@@ -144,7 +144,7 @@ macro_rules! bench_on_backend {
             use burn::backend::wgpu::{Wgpu, WgpuDevice};
             use burn::tensor::f16;
 
-            $fn_name::<Wgpu<f16, i32>>(&WgpuDevice::default(), feature_name, url, token);
+            $fn_name::<Wgpu<f32, i32>>(&WgpuDevice::default(), feature_name, url, token);
         }
 
         #[cfg(feature = "tch-gpu")]
@@ -214,7 +214,7 @@ macro_rules! bench_on_backend {
             use burn::backend::cuda::{Cuda, CudaDevice};
             use burn::tensor::f16;
 
-            $fn_name::<Cuda<f16>>(&CudaDevice::default(), feature_name, url, token);
+            $fn_name::<Cuda<f32>>(&CudaDevice::default(), feature_name, url, token);
         }
 
         #[cfg(feature = "hip")]


### PR DESCRIPTION
```
Benchmarking Burn @ 0.16.0
Benchmarking Burn @ 0.16.0
| Benchmark                         | Feature           | Backend                    | Device        | Median         |
|-----------------------------------|-------------------|----------------------------|---------------|----------------|
| transformer-encoder-inference-f32 | wgpu-spirv        | `jit<wgpu<spirv>>`         | DefaultDevice | 29.362ms       |
| transformer-encoder-training-f32  | wgpu-spirv        | `jit<wgpu<spirv>>`         | DefaultDevice | 96.470ms       |
| transformer-encoder-inference-f32 | wgpu-spirv-fusion | `fusion<jit<wgpu<spirv>>>` | DefaultDevice | 25.199ms       |
| transformer-encoder-training-f32  | wgpu-spirv-fusion | `fusion<jit<wgpu<spirv>>>` | DefaultDevice | 82.012ms       |

Benchmarking Burn @ git+8a6f37c4eca6e56a284ec840f6fd5a8111643f14#0.17.0
Benchmarking Burn @ git+8a6f37c4eca6e56a284ec840f6fd5a8111643f14#0.17.0
| Benchmark                         | Feature           | Backend                       | Device        | Median         |
|-----------------------------------|-------------------|-------------------------------|---------------|----------------|
| transformer-encoder-inference-f32 | wgpu-spirv        | `cubecl<wgpu<spirv>>`         | DefaultDevice | 20.856ms       |
| transformer-encoder-training-f32  | wgpu-spirv        | `cubecl<wgpu<spirv>>`         | DefaultDevice | 66.976ms       |
| transformer-encoder-inference-f32 | wgpu-spirv-fusion | `fusion<cubecl<wgpu<spirv>>>` | DefaultDevice | 16.009ms       |
| transformer-encoder-training-f32  | wgpu-spirv-fusion | `fusion<cubecl<wgpu<spirv>>>` | DefaultDevice | 47.896ms       |

Benchmarking Burn @ git+8a6f37c4eca6e56a284ec840f6fd5a8111643f14#0.17.0
Benchmarking Burn @ git+8a6f37c4eca6e56a284ec840f6fd5a8111643f14#0.17.0
| Benchmark                         | Feature     | Backend                | Device  | Median         |
|-----------------------------------|-------------|------------------------|---------|----------------|
| transformer-encoder-inference-f32 | cuda        | `cubecl<cuda>`         | Cuda(0) | 25.317ms       |
| transformer-encoder-training-f32  | cuda        | `cubecl<cuda>`         | Cuda(0) | 88.000ms       |
| transformer-encoder-inference-f32 | cuda-fusion | `fusion<cubecl<cuda>>` | Cuda(0) | 21.618ms       |
| transformer-encoder-training-f32  | cuda-fusion | `fusion<cubecl<cuda>>` | Cuda(0) | 68.644ms       |
Benchmarking Burn @ 0.16.0
Benchmarking Burn @ 0.16.0
| Benchmark                         | Feature     | Backend                   | Device        | Median         |
|-----------------------------------|-------------|---------------------------|---------------|----------------|
| transformer-encoder-inference-f32 | wgpu        | `jit<wgpu<wgsl>>`         | DefaultDevice | 30.182ms       |
| transformer-encoder-training-f32  | wgpu        | `jit<wgpu<wgsl>>`         | DefaultDevice | 99.966ms       |
| transformer-encoder-inference-f32 | wgpu-fusion | `fusion<jit<wgpu<wgsl>>>` | DefaultDevice | 26.628ms       |
| transformer-encoder-training-f32  | wgpu-fusion | `fusion<jit<wgpu<wgsl>>>` | DefaultDevice | 84.694ms       |

Benchmarking Burn @ git+8a6f37c4eca6e56a284ec840f6fd5a8111643f14#0.17.0
Benchmarking Burn @ git+8a6f37c4eca6e56a284ec840f6fd5a8111643f14#0.17.0
| Benchmark                         | Feature     | Backend                      | Device        | Median         |
|-----------------------------------|-------------|------------------------------|---------------|----------------|
| transformer-encoder-inference-f32 | wgpu        | `cubecl<wgpu<wgsl>>`         | DefaultDevice | 29.654ms       |
| transformer-encoder-training-f32  | wgpu        | `cubecl<wgpu<wgsl>>`         | DefaultDevice | 97.382ms       |
| transformer-encoder-inference-f32 | wgpu-fusion | `fusion<cubecl<wgpu<wgsl>>>` | DefaultDevice | 25.298ms       |
| transformer-encoder-training-f32  | wgpu-fusion | `fusion<cubecl<wgpu<wgsl>>>` | DefaultDevice | 82.440ms       |

```