### PR TITLE
Fail early when trying the Vulkan backend on MacOS

### DIFF
--- a/burnbench/src/__private.rs
+++ b/burnbench/src/__private.rs
@@ -159,6 +159,11 @@ macro_rules! bench_on_backend {
             $crate::bench_on_backend!($fn_name, Metal<$dtype>, device);
         }
 
+        #[cfg(all(target_os = "macos", feature = "vulkan"))]
+        {
+            panic!("vulkan benchmarks are not supported on macOS, use the wgpu backend instead.");
+        }
+
         #[cfg(any(feature = "wgpu", feature = "vulkan"))]
         {
             use burn::backend::Wgpu;


### PR DESCRIPTION
It does not make sense to allow executing the "vulkan" benchmarks on MacOS for now because of the way we fallback on `metal` wgpu backend in CubeCL.  So in the end we don't benchmark Vulkan at all but Metal via wgpu.