### PR TITLE
feat: send benchmarks complete event webhook

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,7 +43,7 @@ on:
         default: "stable"
 
 env:
-  INPUT_FILE: inputs.json
+  INPUTS_FILE: inputs.json
 
 jobs:
   burn-bench:
@@ -82,7 +82,7 @@ jobs:
           echo "GCP Machine Type: ${{ inputs.gcp_machine_type }}"
           echo "GCP Zone: ${{ inputs.gcp_zone }}"
       # ----------------------------------------------------------------------
-      - name: Write inputs to ${{ env.INPUT_FILE }}
+      - name: Write inputs to ${{ env.INPUTS_FILE }}
         run: |
           jq -n \
             --arg bench_config_json '${{ inputs.bench_config_json }}' \
@@ -104,11 +104,11 @@ jobs:
               repo_full: $repo_full,
               rust_toolchain: $rust_toolchain,
               rust_version: $rust_version
-            }' > "$INPUT_FILE"
+            }' > "$INPUTS_FILE"
       # ----------------------------------------------------------------------
       - name: Run benchmarks
         env:
           GITHUB_BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_FILE: ${{ env.INPUT_FILE }}
+          INPUTS_FILE: ${{ env.INPUTS_FILE }}
         run: |
           cargo bb run -b "$BENCHES" -B "$BACKENDS" -V "$VERSIONS" -v -d "$DTYPES" --share

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -120,5 +120,6 @@ jobs:
         env:
           GITHUB_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
           WEBHOOK_INPUTS_FILE: ${{ env.INPUTS_FILE }}
+          WEBHOOK_PAYLOAD_SECRET: ${{ secrets.WEBHOOK_PAYLOAD_SECRET }}
         run: |
           cargo bb run -b "$BENCHES" -B "$BACKENDS" -V "$VERSIONS" -v -d "$DTYPES" --share

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     # note: by design GitHub workflow dispatch events are limited to 10 inputs
     inputs:
-      bench_config_json:
+      burn_bench_config_json:
         description: "JSON config with backends, benches, dtypes, and versions"
         required: false
         default: '{"backends":["wgpu-fusion"],"benches":["matmul"],"dtypes":["f16"],"versions":["main"]}'
@@ -63,9 +63,9 @@ jobs:
       - name: Install jq
         run: sudo apt update && sudo apt install -y jq
       - name: Parse config
-        id: bench_config_json
+        id: burn_bench_config_json
         run: |
-          echo '${{ inputs.bench_config_json }}' > config.json
+          echo '${{ inputs.burn_bench_config_json }}' > config.json
           echo "BACKENDS=$(jq -r '.backends | join(",")' config.json)" >> $GITHUB_ENV
           echo "BENCHES=$(jq -r '.benches | join(",")' config.json)" >> $GITHUB_ENV
           echo "DTYPES=$(jq -r '.dtypes | join(",")' config.json)" >> $GITHUB_ENV
@@ -78,24 +78,32 @@ jobs:
           echo "DTypes: $DTYPES"
           echo "Benchmarks: $BENCHES"
           echo "Repository: ${{ inputs.repo_full }}"
+          echo "Pull Request Number: ${{ inputs.pr_number }}"
           echo "GCP Image Family: ${{ inputs.gcp_image_family }}"
           echo "GCP Machine Type: ${{ inputs.gcp_machine_type }}"
           echo "GCP Zone: ${{ inputs.gcp_zone }}"
       # ----------------------------------------------------------------------
       - name: Write inputs to ${{ env.INPUTS_FILE }}
         run: |
+          PR_NUMBER_INPUT='${{ inputs.pr_number }}'
+          if [[ -z "$PR_NUMBER_INPUT" ]]; then
+            PR_NUMBER_JSON=null
+          else
+            PR_NUMBER_JSON="$PR_NUMBER_INPUT"
+          fi
+
           jq -n \
-            --arg bench_config_json '${{ inputs.bench_config_json }}' \
+            --arg burn_bench_config_json '${{ inputs.burn_bench_config_json }}' \
             --argjson gcp_gpu_attached '${{ inputs.gcp_gpu_attached }}' \
             --arg gcp_image_family '${{ inputs.gcp_image_family }}' \
             --arg gcp_machine_type '${{ inputs.gcp_machine_type }}' \
             --arg gcp_zone '${{ inputs.gcp_zone }}' \
-            --argjson pr_number '${{ inputs.pr_number }}' \
+            --argjson pr_number "$PR_NUMBER_JSON" \
             --arg repo_full '${{ inputs.repo_full }}' \
             --arg rust_toolchain '${{ inputs.rust_toolchain }}' \
             --arg rust_version '${{ inputs.rust_version }}' \
             '{
-              bench_config_json: $bench_config_json,
+              burn_bench_config_json: $burn_bench_config_json,
               gcp_gpu_attached: $gcp_gpu_attached,
               gcp_image_family: $gcp_image_family,
               gcp_machine_type: $gcp_machine_type,
@@ -105,10 +113,12 @@ jobs:
               rust_toolchain: $rust_toolchain,
               rust_version: $rust_version
             }' > "$INPUTS_FILE"
+
+            cat "$INPUTS_FILE"
       # ----------------------------------------------------------------------
       - name: Run benchmarks
         env:
-          GITHUB_BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUTS_FILE: ${{ env.INPUTS_FILE }}
+          GITHUB_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          WEBHOOK_INPUTS_FILE: ${{ env.INPUTS_FILE }}
         run: |
           cargo bb run -b "$BENCHES" -B "$BACKENDS" -V "$VERSIONS" -v -d "$DTYPES" --share

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.toml.bak
 .vscode
 .vs
 .fleet
+
+# used by webhook for benchmark results
+inputs.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ comfy-table = "7.1.4"
 derive-new = { version = "0.7.0", default-features = false }
 dirs = "5.0.1"
 futures-lite = { version = "2.3.0", default-features = false }
+hex = "0.4.3"
+hmac-sha256 = "1.1.12"
 indicatif = "0.17.11"
 log = { version = "0.4.25", default-features = false }
 os_info = "3.10.0"
@@ -38,6 +40,7 @@ serde_json = { version = "1.0.140", default-features = false }
 strum = "0.27.1"
 sysinfo = { version = "0.33.1", features = ["serde"] }
 tracing-subscriber = "0.3.19"
+uuid = { version = "1.17.0", features = ["v4"] }
 wgpu = "24.0.1"
 wsl = "0.1.0"
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,71 @@ Then share results with:
 cargo bb run --share --benches unary --backends wgpu-fusion
 ```
 
+## Development
+
+To develop `burn-bench` using your local development stack (including the benchmark server and website),
+use the alias `cargo bbd` instead of `cargo bb`.
+
+This alias builds `burn-bench` in debug mode and automatically points it to local endpoints.
+
+## Integration with GitHub
+
+### Triggering benchmarks in a Pull-Request
+
+You can trigger benchmark execution on-demand in a pull request by adding the label ci:benchmarks.
+
+The parameters passed to burn-bench are defined in a benchmarks.toml file located at the root of the pull request’s repository.
+
+Below is an example of such a file. Most fields are self-explanatory:
+
+```toml
+[environment]
+gcp_gpu_attached = true
+gcp_image_family = "tracel-ci-ubuntu-2404-amd64-nvidia"
+gcp_machine_type = "g2-standard-4"
+gcp_zone = "us-east1-c"
+repo_full = "tracel-ai/burn"
+rust_toolchain = "stable"
+rust_version = "stable"
+
+[burn-bench]
+backends = ["wgpu"]
+benches = ["matmul"]
+dtypes = ["f32"]
+```
+
+The following diagram outlines the sequence of steps involved in executing benchmarks:
+
+```mermaid
+sequenceDiagram
+    actor Developer
+    participant PR as GitHub Pull Request
+    participant CI as Tracel CI Server
+    participant W as burn-bench Workflow
+    participant BB as burn-bench
+    participant GCP as Google Cloud Platform
+
+    Developer->>PR: Add label "ci:benchmarks"
+    PR-->>CI: Webhook "labeled"
+    CI->>PR: Read file "benchmarks.toml"
+    CI->>W: Dispatch "burn-bench" workflow
+    W-->>CI: Webhook "job queued"
+    CI->>GCP: Start GitHub runner
+    GCP->>W: Register runner
+    W->>W: Write temporary inputs.json
+    W->>BB: Execute with inputs.json & env
+    BB-->>CI: Webhook "completed"
+    CI->>PR: Post benchmark results
+```
+
+### Manually executing the 'benchmarks' workflow
+
+You can also manually execute the [benchmarks.yml workflow][] via the GitHub Actions UI.
+
+When triggering it manually, you’ll need to fill in the required input fields. Each field includes a default value, making them self-explanatory.
+
 ## Contributing
 
 We welcome contributions to improve benchmarking coverage and add new performance tests.
+
+[`benchmarks.yml` workflow]: https://github.com/tracel-ai/burn-bench/actions/workflows/benchmarks.yml

--- a/crates/backend-comparison/Cargo.toml
+++ b/crates/backend-comparison/Cargo.toml
@@ -73,7 +73,7 @@ regex = { workspace = true }
 wgpu = { workspace = true }
 wsl = { workspace = true }
 tempfile = { workspace = true }
-tokio = { version = "1.44", features = ["rt-multi-thread"] }
+tokio = { version = "1.47", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/burnbench/Cargo.toml
+++ b/crates/burnbench/Cargo.toml
@@ -24,6 +24,8 @@ comfy-table = { workspace = true }
 derive-new = { workspace = true }
 dirs = { workspace = true }
 futures-lite = { workspace = true, features = ["std"] }
+hex = { workspace = true }
+hmac-sha256 = { workspace = true }
 indicatif = { workspace = true }
 log = { workspace = true }
 os_info = { workspace = true }
@@ -37,6 +39,7 @@ strum = { workspace = true, features = ["derive"] }
 sysinfo = { workspace = true }
 tracing-subscriber = { workspace = true }
 regex = { workspace = true }
+uuid = { workspace = true }
 wgpu = { workspace = true }
 wsl = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/burnbench/src/lib.rs
+++ b/crates/burnbench/src/lib.rs
@@ -22,7 +22,7 @@ const USER_BENCHMARK_SERVER_URL: &str = if cfg!(debug_assertions) {
 const USER_BENCHMARK_WEBSITE_URL: &str = if cfg!(debug_assertions) || cfg!(test) {
     "http://localhost:4321/"
 } else {
-    "https://burn.devel/"
+    "https://burn.dev/"
 };
 
 #[macro_export]

--- a/crates/burnbench/src/lib.rs
+++ b/crates/burnbench/src/lib.rs
@@ -24,3 +24,16 @@ const USER_BENCHMARK_WEBSITE_URL: &str = if cfg!(debug_assertions) || cfg!(test)
 } else {
     "https://burn.devel/"
 };
+
+#[macro_export]
+macro_rules! ci_errorln {
+    ($($arg:tt)*) => {{
+        if std::env::var("CI").is_ok() {
+            // Print to stdout with ::error prefix for GitHub Actions
+            println!("::error ::{}", format!($($arg)*));
+        } else {
+            // Local dev: print to stderr as usual
+            eprintln!($($arg)*);
+        }
+    }};
+}

--- a/crates/burnbench/src/runner/mod.rs
+++ b/crates/burnbench/src/runner/mod.rs
@@ -4,5 +4,6 @@ mod dependency;
 mod processor;
 mod progressbar;
 mod reports;
+mod workflow;
 
 pub use base::*;

--- a/crates/burnbench/src/runner/reports.rs
+++ b/crates/burnbench/src/runner/reports.rs
@@ -69,50 +69,8 @@ impl BenchmarkCollection {
 
         self
     }
-}
 
-pub struct ShapeFmt<'a> {
-    shapes: &'a Vec<Vec<usize>>,
-}
-
-impl<'a> ShapeFmt<'a> {
-    pub fn new(shapes: &'a Vec<Vec<usize>>) -> Self {
-        Self { shapes }
-    }
-}
-
-impl Display for ShapeFmt<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.shapes.is_empty() {
-            return f.write_str("()");
-        }
-
-        if self.shapes.len() > 1 {
-            f.write_str("[")?;
-        }
-
-        for shape in self.shapes {
-            f.write_str("(")?;
-            for (i, val) in shape.iter().enumerate() {
-                if i == shape.len() - 1 {
-                    f.write_fmt(format_args!("{val}"))?;
-                } else {
-                    f.write_fmt(format_args!("{val}, "))?;
-                }
-            }
-            f.write_str(")")?;
-        }
-
-        if self.shapes.len() > 1 {
-            f.write_str("]")?;
-        }
-
-        Ok(())
-    }
-}
-
-impl Display for BenchmarkCollection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    pub(crate) fn get_ascii_table(&self) -> String {
         let mut records = self.successful_records.clone();
 
         // Sort by benchmark name, then shapes, then median
@@ -188,6 +146,46 @@ impl Display for BenchmarkCollection {
             ]);
         }
 
-        write!(f, "{}", table)
+        table.to_string()
+    }
+}
+
+pub struct ShapeFmt<'a> {
+    shapes: &'a Vec<Vec<usize>>,
+}
+
+impl<'a> ShapeFmt<'a> {
+    pub fn new(shapes: &'a Vec<Vec<usize>>) -> Self {
+        Self { shapes }
+    }
+}
+
+impl Display for ShapeFmt<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.shapes.is_empty() {
+            return f.write_str("()");
+        }
+
+        if self.shapes.len() > 1 {
+            f.write_str("[")?;
+        }
+
+        for shape in self.shapes {
+            f.write_str("(")?;
+            for (i, val) in shape.iter().enumerate() {
+                if i == shape.len() - 1 {
+                    f.write_fmt(format_args!("{val}"))?;
+                } else {
+                    f.write_fmt(format_args!("{val}, "))?;
+                }
+            }
+            f.write_str(")")?;
+        }
+
+        if self.shapes.len() > 1 {
+            f.write_str("]")?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/burnbench/src/runner/workflow.rs
+++ b/crates/burnbench/src/runner/workflow.rs
@@ -19,7 +19,7 @@ pub(crate) fn send_output_results(inputs_file: &str, table: &str, share_link: Op
         Err(e) => return eprintln!("❌ Error reading JSON: {e}"),
     };
 
-    let pr_number = match parse_pr_number(&json) {
+    let pr_number = match json["pr_number"].as_i64().ok_or("Missing 'pr_number'") {
         Ok(n) => n,
         Err(_) => {
             eprintln!("ℹ️ No valid 'pr_number' found. Skipping webhook.");
@@ -64,14 +64,6 @@ pub(crate) fn send_output_results(inputs_file: &str, table: &str, share_link: Op
             eprintln!("❌ Error sending webhook: {e}");
         }
     }
-}
-
-fn parse_pr_number(json: &Value) -> Result<i64, &'static str> {
-    json["pr_number"]
-        .as_str()
-        .ok_or("Missing 'pr_number'")?
-        .parse::<i64>()
-        .map_err(|_| "Invalid 'pr_number'")
 }
 
 fn clean_output(

--- a/crates/burnbench/src/runner/workflow.rs
+++ b/crates/burnbench/src/runner/workflow.rs
@@ -1,0 +1,122 @@
+use regex::Regex;
+use reqwest::{blocking::{Client, Response}, header::CONTENT_TYPE};
+use serde_json::{Map as JsonMap, Value};
+use std::{env, fs::File, io::BufReader};
+
+use hmac_sha256::HMAC;
+use uuid::Uuid;
+
+use crate::USER_BENCHMARK_SERVER_URL;
+
+pub(crate) fn send_output_results(inputs_file: &str, table: &str, share_link: Option<&str>) {
+    let file = match File::open(inputs_file) {
+        Ok(f) => f,
+        Err(e) => return eprintln!("❌ Cannot open inputs file: {e}"),
+    };
+    let reader = BufReader::new(file);
+    let json: Value = match serde_json::from_reader(reader) {
+        Ok(j) => j,
+        Err(e) => return eprintln!("❌ Error reading JSON: {e}"),
+    };
+
+    let pr_number = match parse_pr_number(&json) {
+        Ok(n) => n,
+        Err(_) => {
+            eprintln!("ℹ️ No valid 'pr_number' found. Skipping webhook.");
+            return;
+        }
+    };
+
+    let cleaned = match clean_output(table, share_link) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("❌ Failed to clean output: {e}");
+            return;
+        }
+    };
+
+    let payload = match serialize_result(json, pr_number, cleaned) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("❌ Failed to serialize result: {e}");
+            return;
+        }
+    };
+
+    let (signature, delivery_id) = match build_req_body(&payload) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("❌ Failed to build request: {e}");
+            return;
+        }
+    };
+
+    let post_url = format!("{USER_BENCHMARK_SERVER_URL}burn_bench/webhook/benchmark");
+    match send_result(&post_url, payload, &signature, &delivery_id) {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                println!("✅ Sent 'complete' webhook to server at '{post_url}'.");
+            } else {
+                eprintln!("❌ Webhook failed with status: {}", resp.status());
+            }
+        }
+        Err(e) => {
+            eprintln!("❌ Error sending webhook: {e}");
+        }
+    }
+}
+
+fn parse_pr_number(json: &Value) -> Result<i64, &'static str> {
+    json["pr_number"]
+        .as_str()
+        .ok_or("Missing 'pr_number'")?
+        .parse::<i64>()
+        .map_err(|_| "Invalid 'pr_number'")
+}
+
+fn clean_output(
+    table: &str,
+    share_link: Option<&str>,
+) -> Result<JsonMap<String, Value>, &'static str> {
+    let ansi_re = Regex::new(r"\x1b\[[0-9;]*m").map_err(|_| "Regex compile failed")?;
+    let cleaned_table = ansi_re.replace_all(table, "").to_string();
+
+    let mut map = JsonMap::new();
+    map.insert("table".to_owned(), Value::String(cleaned_table));
+    if let Some(link) = share_link {
+        map.insert("share_link".to_owned(), Value::String(link.to_owned()));
+    }
+
+    Ok(map)
+}
+
+fn serialize_result(
+    mut json: Value,
+    pr_number: i64,
+    cleaned_output: JsonMap<String, Value>,
+) -> Result<Vec<u8>, &'static str> {
+    json["results"] = Value::Object(cleaned_output);
+    json["action"] = Value::String("complete".to_string());
+    json["pr_number"] = Value::Number(serde_json::Number::from(pr_number));
+    serde_json::to_vec(&json).map_err(|_| "Failed to serialize JSON")
+}
+
+fn build_req_body(payload: &[u8]) -> Result<(String, String), &'static str> {
+    let secret =
+        env::var("WEBHOOK_PAYLOAD_SECRET").map_err(|_| "Missing WEBHOOK_PAYLOAD_SECRET")?;
+    let mac = HMAC::mac(&payload, secret.as_bytes());
+    let signature = format!("sha256={}", hex::encode(mac));
+    let delivery_id = Uuid::new_v4().to_string();
+    Ok((signature, delivery_id))
+}
+
+fn send_result(url: &str, payload: Vec<u8>, signature: &str, delivery_id: &str) -> Result<Response, reqwest::Error> {
+    let response = Client::new()
+        .post(url)
+        .header(CONTENT_TYPE, "application/json")
+        .header("X-GitHub-Delivery", delivery_id)
+        .header("X-Hub-Signature-256", signature)
+        .body(payload)
+        .send();
+    response
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2024"
 [dependencies]
 log = "0.4.27"
 strum = "0.27.2"
-tokio = { version = "1.46.1", features = ["full"] }
 tracel-xtask = "=2.1.7"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,8 +3,7 @@ use tracel_xtask::prelude::*;
 #[macros::base_commands(Build, Bump, Check, Compile, Fix, Test)]
 enum Command {}
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     let args = init_xtask::<Command>(parse_args::<Command>()?)?;
     dispatch_base_commands(args)?;
     Ok(())


### PR DESCRIPTION
Send a 'complete' webhook to the server when the benchmarks completes.
It only send it if a `WEBHOOK_INPUTS_FILE` exists. This file is created by the `benchmarks.yml` workflow in `burn-bench` and contains data about the execution context for the webhook.