### PR TITLE
Add bool_select benchmark

### DIFF
--- a/crates/backend-comparison/Cargo.toml
+++ b/crates/backend-comparison/Cargo.toml
@@ -48,7 +48,7 @@ distributed = ["server", "remote"]
 
 [dependencies]
 # Use the last released version to avoid possible breaking changes
-burn = { git = "https://github.com/tracel-ai/burn", default-features = false }
+burn = { git = "https://github.com/tracel-ai/burn", branch = "main", default-features = false }
 
 burnbench = { path = "../burnbench" }
 
@@ -175,3 +175,7 @@ name = "softmax"
 [[bench]]
 harness = false
 name = "grid_sample"
+
+[[bench]]
+harness = false
+name = "bool_select"

--- a/crates/backend-comparison/benches/bool_select.rs
+++ b/crates/backend-comparison/benches/bool_select.rs
@@ -1,0 +1,88 @@
+use burn::tensor::{Bool, Int, Shape, Tensor, TensorData, backend::Backend};
+use burnbench::{Benchmark, BenchmarkResult, run_benchmark};
+use derive_new::new;
+use rand::Rng;
+
+#[cfg(not(feature = "legacy-v16"))]
+use rand::rng;
+#[cfg(feature = "legacy-v16")]
+use rand::thread_rng as rng;
+
+#[derive(new)]
+struct BoolSelectBenchmark<B: Backend, const D: usize> {
+    shape: Shape,
+    dim: usize,
+    indices_count: usize,
+    device: B::Device,
+}
+
+impl<B: Backend, const D: usize> Benchmark for BoolSelectBenchmark<B, D> {
+    type Input = (Tensor<B, D, Bool>, Tensor<B, 1, Int>);
+    type Output = Tensor<B, D, Bool>;
+
+    fn name(&self) -> String {
+        format!("bool_select_dim{}", self.dim)
+    }
+
+    fn shapes(&self) -> Vec<Vec<usize>> {
+        vec![self.shape.dims.clone(), vec![self.indices_count]]
+    }
+
+    fn execute(&self, (tensor, indices): Self::Input) -> Self::Output {
+        tensor.select(self.dim, indices)
+    }
+
+    fn prepare(&self) -> Self::Input {
+        // Create boolean tensor using TensorData
+        let bool_data: Vec<bool> = (0..self.shape.num_elements())
+            .map(|_| rng().random_bool(0.5))
+            .collect();
+        let tensor_data = TensorData::new(bool_data, self.shape.clone());
+        let tensor = Tensor::<B, D, Bool>::from_data(tensor_data, &self.device);
+
+        // Generate valid random indices for the specified dimension
+        let max_index = self.shape.dims[self.dim];
+        let indices_data: Vec<i32> = (0..self.indices_count)
+            .map(|_| rng().random_range(0..max_index) as i32)
+            .collect();
+        let indices_tensor_data = TensorData::new(indices_data, [self.indices_count]);
+        let indices = Tensor::<B, 1, Int>::from_data(indices_tensor_data, &self.device);
+
+        (tensor, indices)
+    }
+
+    fn sync(&self) {
+        B::sync(&self.device)
+    }
+}
+
+#[allow(dead_code)]
+fn bench<B: Backend>(device: &B::Device) -> Vec<BenchmarkResult> {
+    let mut results = Vec::new();
+
+    // Test configurations: (shape, dim, indices_count)
+    let test_configs: Vec<(Shape, usize, usize)> = vec![
+        // Small tensor
+        ([32, 32, 32].into(), 0, 8),
+        // Medium tensor
+        ([64, 128, 256].into(), 1, 16),
+        // Large tensor
+        ([128, 256, 512].into(), 2, 32),
+    ];
+
+    for (shape, dim, indices_count) in test_configs {
+        let benchmark = BoolSelectBenchmark::<B, 3>::new(
+            shape,
+            dim,
+            indices_count,
+            device.clone()
+        );
+        results.push(run_benchmark(benchmark));
+    }
+
+    results
+}
+
+fn main() {
+    burnbench::bench_on_backend!();
+}


### PR DESCRIPTION
## Pull Request Overview

This PR adds a benchmark for `bool_select` operations on boolean tensors to help evaluate performance characteristics and optimization impact.

### Changes

- **New benchmark**: `crates/backend-comparison/benches/bool_select.rs`
- **Configuration**: Added bool_select to `Cargo.toml` for CLI integration
- **Test configurations**: Three tensor sizes with different selection patterns:
  - 32×32×32 tensors with 8 indices (dimension 0)
  - 64×128×256 tensors with 16 indices (dimension 1)
  - 128×256×512 tensors with 32 indices (dimension 2)

### Usage

Run the benchmark for specific backends:
```bash
cargo bb run -b bool_select -B wgpu-fusion candle-cpu ndarray tch-cpu
```

### Context

This benchmark supports evaluation of bool_select performance improvements being implemented in the main Burn repository (related to tracel-ai/burn#3697).