### PR TITLE
fix(bench): Shape type mismatch in data benchmark

### DIFF
--- a/crates/backend-comparison/benches/data.rs
+++ b/crates/backend-comparison/benches/data.rs
@@ -164,7 +164,7 @@ impl<B: Backend, const D: usize> Benchmark for FromMemoryBenchmark<B, D> {
     }
 
     fn shapes(&self) -> Vec<Vec<usize>> {
-        vec![self.data.shape.clone()]
+        vec![self.data.shape.to_vec()]
     }
 
     fn execute(&self, data: Self::Input) -> Self::Output {


### PR DESCRIPTION
\`shapes()\` returns \`Vec<Vec<usize>>\` but line 167 uses \`self.data.shape.clone()\` which returns \`Shape\`, not \`Vec<usize>\`. This causes a compilation error on the \`data\` and \`load-record\` benchmarks.

The fix is \`.to_vec()\` — consistent with line 33 which already does this correctly for the same conversion.

Found while running burn-bench on Apple M5 Max.