### PR TITLE
chore: tracel github actions v11

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -107,8 +107,11 @@ jobs:
       '@gpu:${{ inputs.gcp_gpu_attached }}' ]
     steps:
       # ----------------------------------------------------------------------
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v5
+      - name: Checkout
+        uses: actions/checkout@v6
+      # ----------------------------------------------------------------------
+      - name: Install Rust
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ inputs.rust_toolchain }}
           cache-key: ${{ inputs.rust_version }}-benchmarks


### PR DESCRIPTION
Add timeouts on job steps to avoid long running steps doing nothing.
